### PR TITLE
Multiple Set-Cookie Headers

### DIFF
--- a/lib/Curl.js
+++ b/lib/Curl.js
@@ -315,8 +315,15 @@ function _parseHeaders( headersString ) {
 
 
         header = headers[i].split( ': ' );
-        currHeaders[header[0]] = header[1];
+        if (header[0] === 'Set-Cookie') {
+            if (!currHeaders['Set-Cookie']) {
+                currHeaders['Set-Cookie'] = [];
+            }
 
+            currHeaders['Set-Cookie'].push(header[1]);
+        } else {
+            currHeaders[header[0]] = header[1];
+        }
     }
 
     return result;


### PR DESCRIPTION
The http rfc states that one http response can have multiple set-cookie headers