### PR TITLE
Read more than just one byte at the time.

### DIFF
--- a/src/Easy.cc
+++ b/src/Easy.cc
@@ -338,7 +338,7 @@ namespace NodeLibcurl {
             }
 
 #if UV_VERSION_MAJOR < 1
-            ret = uv_fs_read( uv_default_loop(), &readReq, fd, ptr, 1, offset, NULL );
+            ret = uv_fs_read( uv_default_loop(), &readReq, fd, ptr, n, offset, NULL );
 #else
             uv_buf_t uvbuf = uv_buf_init( ptr, (unsigned int)( n ) );
 

--- a/src/Easy.cc
+++ b/src/Easy.cc
@@ -1643,6 +1643,7 @@ namespace NodeLibcurl {
         obj->toFree = std::make_shared<Easy::ToFree>();
 
         obj->readDataFileDescriptor = -1;
+        obj->readDataOffset = -1;
 
         info.GetReturnValue().Set( info.This() );
     }

--- a/src/Easy.cc
+++ b/src/Easy.cc
@@ -332,7 +332,7 @@ namespace NodeLibcurl {
 
             // get the offset
             curl_off_t offset = obj->readDataOffset;
-            if  ( offset > 0 ){
+            if  ( offset >= 0 ){
                 // increment it for the next read
                 obj->readDataOffset += n;
             }


### PR DESCRIPTION
As you can see in https://github.com/libuv/libuv/blob/v0.10/src/unix/fs.c#L739, https://github.com/libuv/libuv/blob/v0.10/src/unix/fs.c#L182 and https://linux.die.net/man/2/read the fifth parameter to uv_fs_read in older versions of libuv is the number of bytes that we want to read. Reading just one byte at the time slows the transfer down considerably.