### PR TITLE
improve reset(): it should fully reset instance and restore defaults

### DIFF
--- a/lib/Curl.js
+++ b/lib/Curl.js
@@ -1081,8 +1081,12 @@ Curl.prototype.pause = function(bitmask) {
  * @return {module:node-libcurl.Curl} <code>this</code>
  */
 Curl.prototype.reset = function() {
-  //Do we need to remove listeners here?
+  this.removeAllListeners();
   this._handle.reset();
+  
+  // add callbacks back as reset will remove them
+  this._handle.setOpt(_Curl.option.WRITEFUNCTION, this._onData.bind(this));
+  this._handle.setOpt(_Curl.option.HEADERFUNCTION, this._onHeader.bind(this));
 
   return this;
 };


### PR DESCRIPTION
1. reset removes internal WRITE and HEADER handlers with no chance to restore behaviour set in Constructor
2. event listeners should should be restored to default state as reset implies need to reinitialise instance, so it will be more consistent