### PR TITLE
clean chunks and header array in _onError

### DIFF
--- a/lib/Curl.js
+++ b/lib/Curl.js
@@ -864,6 +864,11 @@ Curl.prototype._onHeader = function(chunk /*, size, nmemb*/) {
 Curl.prototype._onError = function(err, errCode) {
   this._isRunning = false;
 
+  this._chunks = [];
+  this._headerChunks = [];
+  this._chunksLength = 0;
+  this._headerChunksLength = 0;
+  
   /**
    * Error event
    *


### PR DESCRIPTION
As _onEnd will only be called if no error happened, there is need to clean chunks and headers in _onError as well.