### PR TITLE
fix #43 mac libs should be linked against @rpath

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -85,7 +85,7 @@ before_install:
   - cd "$TAG"
   - CURL_PREFIX=$HOME
   - if [[ $TRAVIS_OS_NAME == "osx" ]]; then
-      CURL_PREFIX=/usr/local
+      CURL_PREFIX=/usr/local;
     fi
   - ./buildconf && ./configure --prefix=$CURL_PREFIX --with-ssl && make && make install
   - cd $TRAVIS_BUILD_DIR

--- a/.travis.yml
+++ b/.travis.yml
@@ -83,7 +83,7 @@ before_install:
       git clone --branch "$TAG" --depth 1 https://github.com/bagder/curl.git "$TAG";
     fi
   - cd "$TAG"
-  - ./buildconf && ./configure --prefix=$HOME --with-ssl && make && make install
+  - ./buildconf && ./configure --prefix=/opt/local --with-ssl && make && make install
   - cd $TRAVIS_BUILD_DIR
   # output curl version info
   - curl --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -83,7 +83,11 @@ before_install:
       git clone --branch "$TAG" --depth 1 https://github.com/bagder/curl.git "$TAG";
     fi
   - cd "$TAG"
-  - ./buildconf && ./configure --prefix=/usr/local --with-ssl && make && make install
+  - CURL_PREFIX=$HOME
+  - if [[ $TRAVIS_OS_NAME == "osx" ]]; then
+      CURL_PREFIX=/usr/local
+    fi
+  - ./buildconf && ./configure --prefix=$CURL_PREFIX --with-ssl && make && make install
   - cd $TRAVIS_BUILD_DIR
   # output curl version info
   - curl --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -83,7 +83,7 @@ before_install:
       git clone --branch "$TAG" --depth 1 https://github.com/bagder/curl.git "$TAG";
     fi
   - cd "$TAG"
-  - ./buildconf && ./configure --prefix=/opt/local --with-ssl && make && make install
+  - ./buildconf && ./configure --prefix=/usr/local --with-ssl && make && make install
   - cd $TRAVIS_BUILD_DIR
   # output curl version info
   - curl --version

--- a/binding.gyp
+++ b/binding.gyp
@@ -88,6 +88,7 @@
                         ],
                         'LD_RUNPATH_SEARCH_PATHS': [
                           '/opt/local/lib',
+                          '/usr/local/opt/curl/lib',
                           '/usr/local/lib',
                           '/usr/lib'
                         ]

--- a/binding.gyp
+++ b/binding.gyp
@@ -88,6 +88,7 @@
                         ],
                         'LD_RUNPATH_SEARCH_PATHS': [
                           '/opt/local/lib',
+                          '/usr/local/lib',
                           '/usr/lib'
                         ]
                     },

--- a/binding.gyp
+++ b/binding.gyp
@@ -85,13 +85,17 @@
                         'WARNING_CFLAGS':[
                             '-Wno-c++11-narrowing',
                             '-Wno-constant-conversion'
+                        ],
+                        'LD_RUNPATH_SEARCH_PATHS': [
+                          '/opt/local/lib',
+                          '/usr/lib'
                         ]
                     },
                     'include_dirs' : [
                         '<!@(node "<(module_root_dir)/tools/curl-config.js" --cflags | sed s/-I//g)'
                     ],
                     'libraries': [
-                        '<!@(node "<(module_root_dir)/tools/curl-config.js" --libs)'
+                        '-L <!@(node "<(module_root_dir)/tools/curl-config.js" --prefix)/lib -lcurl'
                     ]
                 }]
             ]
@@ -105,7 +109,21 @@
                     'files': [ '<(PRODUCT_DIR)/<(module_name).node' ],
                     'destination': '<(module_path)'
                 }
-            ]
+            ],
+            'conditions': [['OS == "mac"', {
+                'postbuilds': [
+                    {
+                      'postbuild_name': '@rpath for libcurl',
+                      'action': [
+                        'install_name_tool',
+                        '-change',
+                        '<!@(otool -D `curl-config --prefix`/lib/libcurl.dylib | sed -n 2p)',
+                        '@rpath/libcurl.dylib',
+                        '<(module_path)/<(module_name).node'
+                      ],
+                    },
+                ]
+            }]]
         }
     ]
 }


### PR DESCRIPTION
This is fix for #43 mac. The best way how to deal with a problem of absolute paths embedded into binary is to replace the with @rpath, it requires list of paths where to look for libraries. Also I stopped linking against all libs libcurl depends on and link only against libcurl as this binary only depends on libcurl and libcurl itself handling its own dependencies just fine.