### PR TITLE
Fixes httpMethodOptions for curly get

### DIFF
--- a/lib/curly.ts
+++ b/lib/curly.ts
@@ -174,8 +174,10 @@ const create = (): CurlyFunction => {
   }
 
   for (const httpMethod of methods) {
-    const httpMethodOptions =
-      httpMethodOptionsMap[httpMethod] || httpMethodOptionsMap['_']
+    const httpMethodOptionsKey = httpMethodOptionsMap.hasOwnProperty(httpMethod)
+      ? httpMethod
+      : '_'
+    const httpMethodOptions = httpMethodOptionsMap[httpMethodOptionsKey]
 
     // @ts-ignore
     curly[httpMethod] =

--- a/test/curl/curly.spec.ts
+++ b/test/curl/curly.spec.ts
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) Jonathan Cardoso Machado. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import 'should'
+
+import { app, host, port, server } from '../helper/server'
+import { curly } from '../../lib'
+
+const url = `http://${host}:${port}/`
+
+describe('curly', () => {
+  before((done) => {
+    server.listen(port, host, done)
+
+    app.get('/', (_req, res) => {
+      res.send('Hello World!')
+    })
+  })
+
+  after(() => {
+    server.close()
+    app._router.stack.pop()
+  })
+
+  describe('get()', () => {
+    it('is successful', async () => {
+      const { statusCode } = await curly.get(url)
+      statusCode.should.be.equal(200)
+    })
+  })
+})


### PR DESCRIPTION
The change on this line makes `curly.get()` fallback to use `customRequest`: https://github.com/JCMais/node-libcurl/commit/357f01d84aec181cced33dc4f7401dc0218d775b#diff-fef1692ed0abd78502c1313679d7fd3cR178

This changes the check from the value to whether the key exists in `httpMethodOptionsMap`.