### PR TITLE
feat: Apple Silicon support

### DIFF
--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-10.15
+          - macos-11
           - ubuntu-16.04 # TODO(jonathan): bump this to a more recent version when we do a major version bump
         libcurl-release:
           - 7.73.0
@@ -35,7 +35,7 @@ jobs:
           - 14
           - 16
         include:
-          - os: macos-10.15
+          - os: macos-11
             libcurl-release: 7.73.0
             node: 16
             node-libcurl-cpp-std: c++17
@@ -93,9 +93,9 @@ jobs:
           path: |
             ~/.node-gyp
             ~/deps
-          key: v3-${{ runner.os }}-libcurl-deps-cache-node-${{ matrix.node }}
+          key: v4-${{ runner.os }}-libcurl-deps-cache-node-${{ matrix.node }}
           restore-keys: |
-            v3-${{ runner.os }}-libcurl-deps-cache-node-${{ matrix.node }}
+            v4-${{ runner.os }}-libcurl-deps-cache-node-${{ matrix.node }}
       - name: 'Set GIT_TAG'
         if: startsWith(github.ref, 'refs/tags')
         run: echo "GIT_TAG=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
@@ -111,7 +111,7 @@ jobs:
           retention-days: 5
 
   build-and-release-electron:
-    runs-on: macos-10.15
+    runs-on: macos-11
     strategy:
       fail-fast: false
       matrix:
@@ -188,9 +188,9 @@ jobs:
           path: |
             ~/.node-gyp
             ~/deps
-          key: v3-${{ runner.os }}-libcurl-deps-cache-electron-${{ matrix.electron-version }}
+          key: v4-${{ runner.os }}-libcurl-deps-cache-electron-${{ matrix.electron-version }}
           restore-keys: |
-            v3-${{ runner.os }}-libcurl-deps-cache-electron-${{ matrix.electron-version }}
+            v4-${{ runner.os }}-libcurl-deps-cache-electron-${{ matrix.electron-version }}
       - name: 'Set GIT_TAG'
         if: startsWith(github.ref, 'refs/tags')
         run: echo "GIT_TAG=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
@@ -206,7 +206,7 @@ jobs:
           retention-days: 5
 
   build-and-release-nwjs:
-    runs-on: macos-10.15
+    runs-on: macos-11
     strategy:
       fail-fast: false
       matrix:
@@ -273,9 +273,9 @@ jobs:
           path: |
             ~/.node-gyp
             ~/deps
-          key: v3-${{ runner.os }}-libcurl-deps-cache-nwjs-${{ matrix.nwjs-version }}
+          key: v4-${{ runner.os }}-libcurl-deps-cache-nwjs-${{ matrix.nwjs-version }}
           restore-keys: |
-            v3-${{ runner.os }}-libcurl-deps-cache-nwjs-${{ matrix.nwjs-version }}
+            v4-${{ runner.os }}-libcurl-deps-cache-nwjs-${{ matrix.nwjs-version }}
       - name: 'Set GIT_TAG'
         if: startsWith(github.ref, 'refs/tags')
         run: echo "GIT_TAG=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV

--- a/.github/workflows/build-lint-test.yaml
+++ b/.github/workflows/build-lint-test.yaml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-10.15
+          - macos-11
           # removed as we enabled CircleCI to run on PRs
           # - ubuntu-16.04 # TODO(jonathan): bump this to a more recent version when we do a major version bump
         libcurl-release:
@@ -31,12 +31,12 @@ jobs:
           - 16
         include:
           # we only want to run lint in one of the jobs
-          - os: macos-10.15
+          - os: macos-11
             libcurl-release: 7.73.0
             node: 16
             run-lint-and-tsc: true
           # Node.js 16 needs a different cpp std
-          - os: macos-10.15
+          - os: macos-11
             libcurl-release: 7.73.0
             node: 16
             node-libcurl-cpp-std: c++17
@@ -46,7 +46,7 @@ jobs:
           #   node: 16
           #   node-libcurl-cpp-std: c++17
           # we also want to build a job for old libcurl versions
-          - os: macos-10.15
+          - os: macos-11
             libcurl-release: 7.50.0
             node: 16
 
@@ -96,9 +96,9 @@ jobs:
           path: |
             ~/.node-gyp
             ~/deps
-          key: v3-build-lint-test-${{ runner.os }}-libcurl-deps-cache-node-${{ matrix.node }}
+          key: v4-build-lint-test-${{ runner.os }}-libcurl-deps-cache-node-${{ matrix.node }}
           restore-keys: |
-            v3-build-lint-test-${{ runner.os }}-libcurl-deps-cache-node-${{ matrix.node }}
+            v4-build-lint-test-${{ runner.os }}-libcurl-deps-cache-node-${{ matrix.node }}
       - name: 'Install all the stuff'
         run: |
           RUN_TESTS=false \
@@ -130,7 +130,7 @@ jobs:
           retention-days: 3
 
   build-and-test-electron:
-    runs-on: macos-10.15
+    runs-on: macos-11
     strategy:
       fail-fast: false
       matrix:
@@ -207,9 +207,9 @@ jobs:
           path: |
             ~/.node-gyp
             ~/deps
-          key: v3-build-lint-test-${{ runner.os }}-libcurl-deps-cache-electron-${{ matrix.electron-version }}
+          key: v4-build-lint-test-${{ runner.os }}-libcurl-deps-cache-electron-${{ matrix.electron-version }}
           restore-keys: |
-            v3-build-lint-test-${{ runner.os }}-libcurl-deps-cache-electron-${{ matrix.electron-version }}
+            v4-build-lint-test-${{ runner.os }}-libcurl-deps-cache-electron-${{ matrix.electron-version }}
       - name: 'Set GIT_TAG'
         if: startsWith(github.ref, 'refs/tags')
         run: echo "GIT_TAG=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
@@ -228,7 +228,7 @@ jobs:
           retention-days: 5
 
   build-and-test-nwjs:
-    runs-on: macos-10.15
+    runs-on: macos-11
     strategy:
       fail-fast: false
       matrix:
@@ -295,9 +295,9 @@ jobs:
           path: |
             ~/.node-gyp
             ~/deps
-          key: v3-build-lint-test-${{ runner.os }}-libcurl-deps-cache-nwjs-${{ matrix.nwjs-version }}
+          key: v4-build-lint-test-${{ runner.os }}-libcurl-deps-cache-nwjs-${{ matrix.nwjs-version }}
           restore-keys: |
-            v3-build-lint-test-${{ runner.os }}-libcurl-deps-cache-nwjs-${{ matrix.nwjs-version }}
+            v4-build-lint-test-${{ runner.os }}-libcurl-deps-cache-nwjs-${{ matrix.nwjs-version }}
       - name: 'Set GIT_TAG'
         if: startsWith(github.ref, 'refs/tags')
         run: echo "GIT_TAG=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV

--- a/binding.gyp
+++ b/binding.gyp
@@ -12,6 +12,7 @@
     'curl_config_bin%': 'node <(module_root_dir)/scripts/curl-config.js',
     'node_libcurl_no_setlocale%': 'false',
     'node_libcurl_cpp_std%': '<!(node <(module_root_dir)/scripts/cpp-std.js)',
+    'macos_universal_build%': 'false',
   },
   'targets': [
     {
@@ -181,6 +182,22 @@
                   '/usr/local/lib',
                   '/usr/lib'
                 ],
+              }
+            }],
+            ['macos_universal_build=="true"', {
+              'xcode_settings': {
+                'OTHER_CPLUSPLUSFLAGS' : [
+                  '-arch x86_64',
+                  '-arch arm64'
+                ],
+                'OTHER_CFLAGS': [
+                  '-arch x86_64',
+                  '-arch arm64'
+                ],
+                'OTHER_LDFLAGS': [
+                  '-arch x86_64',
+                  '-arch arm64'
+                ]
               }
             }]
           ],

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "@mapbox/node-pre-gyp": "1.0.5",
     "env-paths": "2.2.0",
     "nan": "2.15.0",
-    "node-gyp": "7.1.2",
+    "node-gyp": "8.2.0",
     "npmlog": "4.1.2",
     "rimraf": "^3.0.2",
     "tslib": "2.0.1"

--- a/scripts/ci/build-libunistring.sh
+++ b/scripts/ci/build-libunistring.sh
@@ -11,6 +11,8 @@ mkdir -p $2/source
 
 FORCE_REBUILD=${FORCE_REBUILD:-}
 
+MACOS_UNIVERSAL_BUILD=${MACOS_UNIVERSAL_BUILD:-}
+
 # @TODO We are explicitly checking the static lib
 if [[ -f $build_folder/lib/libunistring.a ]] && [[ -z $FORCE_REBUILD || $FORCE_REBUILD != "true" ]]; then
   echo "Skipping rebuild of libunistring because lib file already exists"

--- a/scripts/ci/build-libunistring.sh
+++ b/scripts/ci/build-libunistring.sh
@@ -29,33 +29,56 @@ fi
 
 CFLAGS=${CFLAGS:-}
 
-# @TODO Verify if iconv is required on musl
-# 
-# 
-# * GNU libiconv
-#   + Not needed on systems with
-#       - glibc 2.2 or newer, or
-#       - MacOS X 10.3 or newer, or
-#       - NetBSD 3.0 or newer.
-#     But highly recommended on all other systems.
-#     Needed for character set conversion of strings from/to Unicode.
-#   + Homepage:
-#     https://www.gnu.org/software/libiconv/
-#   + Download:
-#     https://mirrors.kernel.org/gnu/libiconv/
-#   + If it is installed in a nonstandard directory, pass the option
-#     --with-libiconv-prefix=DIR to 'configure'.
+build() {
+  # @TODO Verify if iconv is required on musl
+  # 
+  # 
+  # * GNU libiconv
+  #   + Not needed on systems with
+  #       - glibc 2.2 or newer, or
+  #       - MacOS X 10.3 or newer, or
+  #       - NetBSD 3.0 or newer.
+  #     But highly recommended on all other systems.
+  #     Needed for character set conversion of strings from/to Unicode.
+  #   + Homepage:
+  #     https://www.gnu.org/software/libiconv/
+  #   + Download:
+  #     https://mirrors.kernel.org/gnu/libiconv/
+  #   + If it is installed in a nonstandard directory, pass the option
+  #     --with-libiconv-prefix=DIR to 'configure'.
 
-# Debug
-# CFLAGS="$CFLAGS -fPIC" ./configure --prefix=$build_folder --disable-shared --debug "${@:3}"
+  # Debug
+  # CFLAGS="$CFLAGS -fPIC" ./configure --prefix=$build_folder --disable-shared --debug $1
 
-# Release - Static
-# --with-libiconv-prefix=$LIBICONV_BUILD_FOLDER \
-CFLAGS="$CFLAGS -fPIC" ./configure \
-  --prefix=$build_folder \
-  --disable-shared "${@:3}"
+  # Release - Static
+  # --with-libiconv-prefix=$LIBICONV_BUILD_FOLDER \
+  CFLAGS="$CFLAGS -fPIC" ./configure \
+    --prefix=$build_folder \
+    --disable-shared "$@"
 
-# Release - Both
-# CFLAGS="$CFLAGS -fPIC" ./configure --prefix=$build_folder "${@:3}"
+  # Release - Both
+  # CFLAGS="$CFLAGS -fPIC" ./configure --prefix=$build_folder $1
 
-make && make install
+  make && make install
+}
+
+if [ "$MACOS_UNIVERSAL_BUILD" == "true" ]; then
+  # libunistring does not build universally, so we need to build two binaries
+  # and merge them. This is a bit ugly...
+
+  build_arch() {
+    CFLAGS="$MACOS_TARGET_FLAGS -arch $1" \
+    LDFLAGS="$MACOS_TARGET_FLAGS -arch $1" \
+    build --host=$2-apple-macosx "${@:3}"
+    mv $build_folder/lib/libunistring{,-$1}.a
+  }
+
+  build_arch x86_64 x86_64 "${@:3}"
+  make distclean || true
+  build_arch arm64 aarch64 "${@:3}"
+
+  lipo -create -output $build_folder/lib/libunistring.a \
+    $build_folder/lib/libunistring-{x86_64,arm64}.a
+else
+  build "${@:3}"
+fi

--- a/scripts/ci/build-openssl.sh
+++ b/scripts/ci/build-openssl.sh
@@ -10,6 +10,8 @@ mkdir -p $2/source
 
 FORCE_REBUILD=${FORCE_REBUILD:-}
 
+MACOS_UNIVERSAL_BUILD=${MACOS_UNIVERSAL_BUILD:-}
+
 # @TODO We are explicitly checking the static lib
 if [[ -f $build_folder/lib/libcrypto.a && -f $build_folder/lib/libssl.a ]] && [[ -z $FORCE_REBUILD || $FORCE_REBUILD != "true" ]]; then
   echo "Skipping rebuild of openssl because lib files already exists"

--- a/scripts/ci/build.sh
+++ b/scripts/ci/build.sh
@@ -406,12 +406,14 @@ if [[ $PUBLISH_BINARY == true && $LIBCURL_RELEASE == $LATEST_LIBCURL_RELEASE ]];
     # Build and publish x64 package
     lipo build/Release/node_libcurl.node -thin x86_64 -output lib/binding/node_libcurl.node
     npm_config_target_arch=x64 yarn pregyp package testpackage --verbose
-    npm_config_target_arch=x64 node scripts/module-packaging.js --publish "$(yarn --silent pregyp reveal staged_tarball --silent)"
+    npm_config_target_arch=x64 node scripts/module-packaging.js --publish \
+      "$(npm_config_target_arch=x64 yarn --silent pregyp reveal staged_tarball --silent)"
   
     # Build and publish arm64 package.
     lipo build/Release/node_libcurl.node -thin arm64 -output lib/binding/node_libcurl.node
-    npm_config_target_arch=x64 yarn pregyp package --verbose  # Can't testpackage for arm64 yet.
-    npm_config_target_arch=arm64 node scripts/module-packaging.js --publish "$(yarn --silent pregyp reveal staged_tarball --silent)"
+    npm_config_target_arch=arm64 yarn pregyp package --verbose  # Can't testpackage for arm64 yet.
+    npm_config_target_arch=arm64 node scripts/module-packaging.js --publish \
+      "$(npm_config_target_arch=arm64 yarn --silent pregyp reveal staged_tarball --silent)"
   else
     yarn pregyp package testpackage --verbose
     node scripts/module-packaging.js --publish "$(yarn --silent pregyp reveal staged_tarball --silent)"

--- a/scripts/ci/build.sh
+++ b/scripts/ci/build.sh
@@ -17,12 +17,28 @@ FORCE_REBUILD=false
 
 export FORCE_REBUILD=$FORCE_REBUILD
 
+MACOS_UNIVERSAL_BUILD=${MACOS_UNIVERSAL_BUILD:-}
+
 if [ "$(uname)" == "Darwin" ]; then
+  # Default to universal build, if possible.
+  if [ -z "$MACOS_UNIVERSAL_BUILD" ]; then
+    export MACOS_UNIVERSAL_BUILD="$(node -e "console.log(process.versions.openssl >= '1.1.1i')")"
+  fi
+
+  if [ "$MACOS_UNIVERSAL_BUILD" == "true" ]; then
+    export CMAKE_OSX_ARCHITECTURES="arm64;x86_64"
+    export MACOS_ARCH_FLAGS="-arch arm64 -arch x86_64"
+  else
+    export MACOS_ARCH_FLAGS=""
+  fi
+
   export MACOSX_DEPLOYMENT_TARGET=10.12
-  export CFLAGS="-mmacosx-version-min=10.12"
-  export CCFLAGS="-mmacosx-version-min=10.12"
-  export CXXFLAGS="-mmacosx-version-min=10.12"
-  export LDFLAGS="-mmacosx-version-min=10.12"
+  export MACOS_TARGET_FLAGS="-mmacosx-version-min=$MACOSX_DEPLOYMENT_TARGET"
+
+  export CFLAGS="$MACOS_TARGET_FLAGS $MACOS_ARCH_FLAGS"
+  export CCFLAGS="$MACOS_TARGET_FLAGS"
+  export CXXFLAGS="$MACOS_TARGET_FLAGS"
+  export LDFLAGS="$MACOS_TARGET_FLAGS $MACOS_ARCH_FLAGS"
 fi
 
 function cat_slower() {
@@ -331,6 +347,7 @@ export npm_config_curl_config_bin="$LIBCURL_DEST_FOLDER/build/$LIBCURL_RELEASE/b
 export npm_config_curl_static_build="true"
 export npm_config_node_libcurl_cpp_std="$NODE_LIBCURL_CPP_STD"
 export npm_config_build_from_source="true"
+export npm_config_macos_universal_build="${MACOS_UNIVERSAL_BUILD:-false}"
 export npm_config_runtime="$runtime"
 export npm_config_dist_url="$dist_url"
 export npm_config_target="$target"
@@ -340,6 +357,7 @@ echo "npm_config_curl_config_bin=$npm_config_curl_config_bin"
 echo "npm_config_curl_static_build=$npm_config_curl_static_build"
 echo "npm_config_node_libcurl_cpp_std=$npm_config_node_libcurl_cpp_std"
 echo "npm_config_build_from_source=$npm_config_build_from_source"
+echo "npm_config_macos_universal_build=$npm_config_macos_universal_build"
 echo "npm_config_runtime=$npm_config_runtime"
 echo "npm_config_dist_url=$npm_config_dist_url"
 echo "npm_config_target=$npm_config_target"

--- a/scripts/ci/build.sh
+++ b/scripts/ci/build.sh
@@ -396,8 +396,26 @@ fi
 # Check if we need to publish the binaries
 if [[ $PUBLISH_BINARY == true && $LIBCURL_RELEASE == $LATEST_LIBCURL_RELEASE ]]; then
   echo "Publish binary is true - Testing and publishing package with pregyp"
-  yarn pregyp package testpackage --verbose
-  node scripts/module-packaging.js --publish "$(yarn --silent pregyp reveal staged_tarball --silent)"
+  if [[ "$MACOS_UNIVERSAL_BUILD" == "true" ]]; then
+    # Need to publish two binaries when doing a universal build.
+    #
+    # Could also publish the universal build twice instead, but it might not
+    # play well with electron-builder which will try to lipo native add-ons
+    # for different architectures.
+    # --
+    # Build and publish x64 package
+    lipo build/Release/node_libcurl.node -thin x86_64 -output lib/binding/node_libcurl.node
+    npm_config_target_arch=x64 yarn pregyp package testpackage --verbose
+    npm_config_target_arch=x64 node scripts/module-packaging.js --publish "$(yarn --silent pregyp reveal staged_tarball --silent)"
+  
+    # Build and publish arm64 package.
+    lipo build/Release/node_libcurl.node -thin arm64 -output lib/binding/node_libcurl.node
+    npm_config_target_arch=x64 yarn pregyp package --verbose  # Can't testpackage for arm64 yet.
+    npm_config_target_arch=arm64 node scripts/module-packaging.js --publish "$(yarn --silent pregyp reveal staged_tarball --silent)"
+  else
+    yarn pregyp package testpackage --verbose
+    node scripts/module-packaging.js --publish "$(yarn --silent pregyp reveal staged_tarball --silent)"
+  fi
 fi
 
 # In case we published the binaries, verify if we can download them, and that they work

--- a/yarn.lock
+++ b/yarn.lock
@@ -382,6 +382,11 @@
     reflect-metadata "^0.1.12"
     tslib "^1.8.1"
 
+"@gar/promisify@^1.0.1":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.2.tgz#30aa825f11d438671d585bd44e7fd564535fc210"
+  integrity sha512-82cpyJyKRoQoRi+14ibCeGPu0CwypgtBAdBhq1WfvagpCZNKqwXbKwXllYSMG91DhmG4jt9gN8eP6lGOtozuaw==
+
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
   resolved "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz#fd3db1d59ecf7cf121e80650bb86712f9b55eced"
@@ -477,6 +482,22 @@
     "@nodelib/fs.scandir" "2.1.3"
     fastq "^1.6.0"
 
+"@npmcli/fs@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@npmcli/fs/-/fs-1.0.0.tgz#589612cfad3a6ea0feafcb901d29c63fd52db09f"
+  integrity sha512-8ltnOpRR/oJbOp8vaGUnipOi3bqkcW+sLHFlyXIr08OGHmVJLB1Hn7QtGXbYcpVtH1gAYZTlmDXtE4YV0+AMMQ==
+  dependencies:
+    "@gar/promisify" "^1.0.1"
+    semver "^7.3.5"
+
+"@npmcli/move-file@^1.0.1":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@npmcli/move-file/-/move-file-1.1.2.tgz#1a82c3e372f7cae9253eb66d72543d6b8685c674"
+  integrity sha512-1SUf/Cg2GzGDyaf15aR9St9TWlb+XvbZXWpDx8YKs7MLzMH/BCeopv+y9vzrzgkfykCGuWOlSu3mZhj2+FQcrg==
+  dependencies:
+    mkdirp "^1.0.4"
+    rimraf "^3.0.2"
+
 "@rushstack/node-core-library@3.34.3":
   version "3.34.3"
   resolved "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-3.34.3.tgz#a59a1e452dcc79bd4e5f0840b4e9603551668f85"
@@ -541,6 +562,11 @@
   integrity sha512-PyRA9sm1Yayuj5OIoJ1hGt2YISX45w9WcFbh6ddT0Z/0yaFxOtGLInr4jUfU1EAFVs0Yfyfev4RNwBlUaHdlDQ==
   dependencies:
     defer-to-connect "^2.0.0"
+
+"@tootallnate/once@1":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
+  integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
 
 "@types/argparse@1.0.38":
   version "1.0.38"
@@ -824,12 +850,21 @@ acorn@^7.4.0:
   resolved "https://registry.npmjs.org/acorn/-/acorn-7.4.0.tgz#e1ad486e6c54501634c6c397c5c121daa383607c"
   integrity sha512-+G7P8jJmCHr+S+cLfQxygbWhXy+8YTVGzAkpEbcLo2mLoL7tij/VG41QSHACSf5QgYRhMZYHuNc6drJaO0Da+w==
 
-agent-base@6:
+agent-base@6, agent-base@^6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.2.tgz#49fff58577cfee3f37176feab4c22e00f86d7f77"
   integrity sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==
   dependencies:
     debug "4"
+
+agentkeepalive@^4.1.3:
+  version "4.1.4"
+  resolved "https://registry.yarnpkg.com/agentkeepalive/-/agentkeepalive-4.1.4.tgz#d928028a4862cb11718e55227872e842a44c945b"
+  integrity sha512-+V/rGa3EuU74H6wR04plBb7Ks10FbtUQgRj/FQOG7uUIEuaINI+AiqJR1k6t3SVNs7o7ZjIdus6706qqzVq8jQ==
+  dependencies:
+    debug "^4.1.0"
+    depd "^1.1.2"
+    humanize-ms "^1.2.1"
 
 aggregate-error@^3.0.0:
   version "3.1.0"
@@ -1202,6 +1237,30 @@ bytes@3.1.0:
   version "3.1.0"
   resolved "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz#f6cf7933a360e0588fa9fde85651cdc7f805d1f6"
   integrity sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==
+
+cacache@^15.0.5:
+  version "15.3.0"
+  resolved "https://registry.yarnpkg.com/cacache/-/cacache-15.3.0.tgz#dc85380fb2f556fe3dda4c719bfa0ec875a7f1eb"
+  integrity sha512-VVdYzXEn+cnbXpFgWs5hTT7OScegHVmLhJIR8Ufqk3iFD6A6j5iSX1KuBTfNEv4tdJWE2PzA6IVFtcLC7fN9wQ==
+  dependencies:
+    "@npmcli/fs" "^1.0.0"
+    "@npmcli/move-file" "^1.0.1"
+    chownr "^2.0.0"
+    fs-minipass "^2.0.0"
+    glob "^7.1.4"
+    infer-owner "^1.0.4"
+    lru-cache "^6.0.0"
+    minipass "^3.1.1"
+    minipass-collect "^1.0.2"
+    minipass-flush "^1.0.5"
+    minipass-pipeline "^1.2.2"
+    mkdirp "^1.0.3"
+    p-map "^4.0.0"
+    promise-inflight "^1.0.1"
+    rimraf "^3.0.2"
+    ssri "^8.0.1"
+    tar "^6.0.2"
+    unique-filename "^1.1.1"
 
 cacheable-lookup@^2.0.0:
   version "2.0.1"
@@ -1793,9 +1852,9 @@ delegates@^1.0.0:
   resolved "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
   integrity sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=
 
-depd@~1.1.2:
+depd@^1.1.2, depd@~1.1.2:
   version "1.1.2"
-  resolved "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
+  resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
   integrity sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=
 
 destroy@~1.0.4:
@@ -1979,6 +2038,13 @@ encodeurl@~1.0.2:
   resolved "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
   integrity sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=
 
+encoding@^0.1.12:
+  version "0.1.13"
+  resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.13.tgz#56574afdd791f54a8e9b2785c0582a2d26210fa9"
+  integrity sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==
+  dependencies:
+    iconv-lite "^0.6.2"
+
 end-of-stream@^1.1.0:
   version "1.4.4"
   resolved "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz#5ae64a5f45057baf3626ec14da0ca5e4b2431eb0"
@@ -2007,6 +2073,11 @@ env-paths@2.2.0, env-paths@^2.2.0:
   version "2.2.0"
   resolved "https://registry.npmjs.org/env-paths/-/env-paths-2.2.0.tgz#cdca557dc009152917d6166e2febe1f039685e43"
   integrity sha512-6u0VYSCo/OW6IoD5WCLLy9JUGARbamfSavcNXry/eu8aHVFei6CD3Sw+VGX5alea1i9pgPHW0mbu6Xj0uBh7gA==
+
+err-code@^2.0.2:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/err-code/-/err-code-2.0.3.tgz#23c2f3b756ffdfc608d30e27c9a941024807e7f9"
+  integrity sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==
 
 error-ex@^1.2.0, error-ex@^1.3.1:
   version "1.3.2"
@@ -2858,7 +2929,7 @@ got@^9.6.0:
     to-readable-stream "^1.0.0"
     url-parse-lax "^3.0.0"
 
-graceful-fs@^4.1.15, graceful-fs@^4.2.3:
+graceful-fs@^4.1.15:
   version "4.2.4"
   resolved "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz#2256bde14d3632958c465ebc96dc467ca07a29fb"
   integrity sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==
@@ -2867,6 +2938,11 @@ graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0:
   version "4.2.3"
   resolved "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz#4a12ff1b60376ef09862c2093edd908328be8423"
   integrity sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==
+
+graceful-fs@^4.2.6:
+  version "4.2.8"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.8.tgz#e412b8d33f5e006593cbd3cee6df9f2cebbe802a"
+  integrity sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==
 
 growl@1.10.5:
   version "1.10.5"
@@ -3004,9 +3080,9 @@ http-auth@^4.1.2:
     bcryptjs "^2.4.3"
     uuid "^3.4.0"
 
-http-cache-semantics@^4.0.0:
+http-cache-semantics@^4.0.0, http-cache-semantics@^4.1.0:
   version "4.1.0"
-  resolved "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz#49e91c5cbf36c9b94bcfcd71c23d5249ec74e390"
+  resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz#49e91c5cbf36c9b94bcfcd71c23d5249ec74e390"
   integrity sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==
 
 http-errors@1.7.2:
@@ -3031,6 +3107,15 @@ http-errors@~1.7.2:
     statuses ">= 1.5.0 < 2"
     toidentifier "1.0.0"
 
+http-proxy-agent@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz#8a8c8ef7f5932ccf953c296ca8291b95aa74aa3a"
+  integrity sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==
+  dependencies:
+    "@tootallnate/once" "1"
+    agent-base "6"
+    debug "4"
+
 http-signature@~1.2.0:
   version "1.2.0"
   resolved "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz#9aecd925114772f3d95b65a60abb8f7c18fbace1"
@@ -3052,6 +3137,13 @@ human-signals@^1.1.1:
   version "1.1.1"
   resolved "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz#c5b1cd14f50aeae09ab6c59fe63ba3395fe4dfa3"
   integrity sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==
+
+humanize-ms@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/humanize-ms/-/humanize-ms-1.2.1.tgz#c46e3159a293f6b896da29316d8b6fe8bb79bbed"
+  integrity sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=
+  dependencies:
+    ms "^2.0.0"
 
 husky@^4.3.0:
   version "4.3.0"
@@ -3075,6 +3167,13 @@ iconv-lite@0.4.24, iconv-lite@^0.4.24:
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
+
+iconv-lite@^0.6.2:
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.3.tgz#a52f80bf38da1952eb5c681790719871a1a72501"
+  integrity sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3.0.0"
 
 ignore@^4.0.6:
   version "4.0.6"
@@ -3118,6 +3217,11 @@ indent-string@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz#624f8f4497d619b2d9768531d58f4122854d7251"
   integrity sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==
+
+infer-owner@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/infer-owner/-/infer-owner-1.0.4.tgz#c4cefcaa8e51051c2a40ba2ce8a3d27295af9467"
+  integrity sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==
 
 inflight@^1.0.4:
   version "1.0.6"
@@ -3198,6 +3302,11 @@ inversify@^5.0.0:
   version "5.0.1"
   resolved "https://registry.npmjs.org/inversify/-/inversify-5.0.1.tgz#500d709b1434896ce5a0d58915c4a4210e34fb6e"
   integrity sha512-Ieh06s48WnEYGcqHepdsJUIJUXpwH5o5vodAX+DK2JA/gjy4EbEcQZxw+uFfzysmKjiLXGYwNG3qDZsKVMcINQ==
+
+ip@^1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/ip/-/ip-1.1.5.tgz#bdded70114290828c0a039e72ef25f5aaec4354a"
+  integrity sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=
 
 ipaddr.js@1.9.1:
   version "1.9.1"
@@ -3289,6 +3398,11 @@ is-installed-globally@^0.3.1:
   dependencies:
     global-dirs "^2.0.1"
     is-path-inside "^3.0.1"
+
+is-lambda@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-lambda/-/is-lambda-1.0.1.tgz#3d9877899e6a53efc0160504cde15f82e6f061d5"
+  integrity sha1-PZh3iZ5qU+/AFgUEzeFfgubwYdU=
 
 is-npm@^4.0.0:
   version "4.0.0"
@@ -3931,6 +4045,27 @@ make-error@^1.1.1:
   resolved "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
   integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
 
+make-fetch-happen@^8.0.14:
+  version "8.0.14"
+  resolved "https://registry.yarnpkg.com/make-fetch-happen/-/make-fetch-happen-8.0.14.tgz#aaba73ae0ab5586ad8eaa68bd83332669393e222"
+  integrity sha512-EsS89h6l4vbfJEtBZnENTOFk8mCRpY5ru36Xe5bcX1KYIli2mkSHqoFsp5O1wMDvTJJzxe/4THpCTtygjeeGWQ==
+  dependencies:
+    agentkeepalive "^4.1.3"
+    cacache "^15.0.5"
+    http-cache-semantics "^4.1.0"
+    http-proxy-agent "^4.0.1"
+    https-proxy-agent "^5.0.0"
+    is-lambda "^1.0.1"
+    lru-cache "^6.0.0"
+    minipass "^3.1.3"
+    minipass-collect "^1.0.2"
+    minipass-fetch "^1.3.2"
+    minipass-flush "^1.0.5"
+    minipass-pipeline "^1.2.4"
+    promise-retry "^2.0.1"
+    socks-proxy-agent "^5.0.0"
+    ssri "^8.0.0"
+
 map-age-cleaner@^0.1.1:
   version "0.1.3"
   resolved "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz#7d583a7306434c055fe474b0f45078e6e1b4b92a"
@@ -4100,6 +4235,45 @@ minimist@^1.2.0, minimist@^1.2.5:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
 
+minipass-collect@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/minipass-collect/-/minipass-collect-1.0.2.tgz#22b813bf745dc6edba2576b940022ad6edc8c617"
+  integrity sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==
+  dependencies:
+    minipass "^3.0.0"
+
+minipass-fetch@^1.3.2:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/minipass-fetch/-/minipass-fetch-1.4.1.tgz#d75e0091daac1b0ffd7e9d41629faff7d0c1f1b6"
+  integrity sha512-CGH1eblLq26Y15+Azk7ey4xh0J/XfJfrCox5LDJiKqI2Q2iwOLOKrlmIaODiSQS8d18jalF6y2K2ePUm0CmShw==
+  dependencies:
+    minipass "^3.1.0"
+    minipass-sized "^1.0.3"
+    minizlib "^2.0.0"
+  optionalDependencies:
+    encoding "^0.1.12"
+
+minipass-flush@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/minipass-flush/-/minipass-flush-1.0.5.tgz#82e7135d7e89a50ffe64610a787953c4c4cbb373"
+  integrity sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==
+  dependencies:
+    minipass "^3.0.0"
+
+minipass-pipeline@^1.2.2, minipass-pipeline@^1.2.4:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz#68472f79711c084657c067c5c6ad93cddea8214c"
+  integrity sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==
+  dependencies:
+    minipass "^3.0.0"
+
+minipass-sized@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/minipass-sized/-/minipass-sized-1.0.3.tgz#70ee5a7c5052070afacfbc22977ea79def353b70"
+  integrity sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==
+  dependencies:
+    minipass "^3.0.0"
+
 minipass@^3.0.0:
   version "3.1.3"
   resolved "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz#7d42ff1f39635482e15f9cdb53184deebd5815fd"
@@ -4107,7 +4281,14 @@ minipass@^3.0.0:
   dependencies:
     yallist "^4.0.0"
 
-minizlib@^2.1.1:
+minipass@^3.1.0, minipass@^3.1.1, minipass@^3.1.3:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-3.1.5.tgz#71f6251b0a33a49c01b3cf97ff77eda030dff732"
+  integrity sha512-+8NzxD82XQoNKNrl1d/FSi+X8wAEWR+sbYAfIvub4Nz0d22plFG72CEVVaufV8PNf4qSslFTD8VMOxNVhHCjTw==
+  dependencies:
+    yallist "^4.0.0"
+
+minizlib@^2.0.0, minizlib@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-2.1.2.tgz#e90d3466ba209b932451508a11ce3d3632145931"
   integrity sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==
@@ -4129,7 +4310,7 @@ mkdirp@^0.5.1, mkdirp@^0.5.3:
   dependencies:
     minimist "^1.2.5"
 
-mkdirp@^1.0.3:
+mkdirp@^1.0.3, mkdirp@^1.0.4:
   version "1.0.4"
   resolved "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
@@ -4178,6 +4359,11 @@ ms@2.1.2, ms@^2.1.1:
   version "2.1.2"
   resolved "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
+
+ms@^2.0.0:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
+  integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
 mute-stream@0.0.7:
   version "0.0.7"
@@ -4231,20 +4417,20 @@ node-fetch@^2.6.1:
   dependencies:
     whatwg-url "^5.0.0"
 
-node-gyp@7.1.2:
-  version "7.1.2"
-  resolved "https://registry.yarnpkg.com/node-gyp/-/node-gyp-7.1.2.tgz#21a810aebb187120251c3bcec979af1587b188ae"
-  integrity sha512-CbpcIo7C3eMu3dL1c3d0xw449fHIGALIJsRP4DDPHpyiW8vcriNY7ubh9TE4zEKfSxscY7PjeFnshE7h75ynjQ==
+node-gyp@8.2.0:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/node-gyp/-/node-gyp-8.2.0.tgz#ef509ccdf5cef3b4d93df0690b90aa55ff8c7977"
+  integrity sha512-KG8SdcoAnw2d6augGwl1kOayALUrXW/P2uOAm2J2+nmW/HjZo7y+8TDg7LejxbekOOSv3kzhq+NSUYkIDAX8eA==
   dependencies:
     env-paths "^2.2.0"
     glob "^7.1.4"
-    graceful-fs "^4.2.3"
+    graceful-fs "^4.2.6"
+    make-fetch-happen "^8.0.14"
     nopt "^5.0.0"
     npmlog "^4.1.2"
-    request "^2.88.2"
     rimraf "^3.0.2"
-    semver "^7.3.2"
-    tar "^6.0.2"
+    semver "^7.3.5"
+    tar "^6.1.2"
     which "^2.0.2"
 
 node-preload@^0.2.1:
@@ -4847,6 +5033,19 @@ progress@^2.0.0, progress@^2.0.3:
   resolved "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
 
+promise-inflight@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
+  integrity sha1-mEcocL8igTL8vdhoEputEsPAKeM=
+
+promise-retry@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/promise-retry/-/promise-retry-2.0.1.tgz#ff747a13620ab57ba688f5fc67855410c370da22"
+  integrity sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==
+  dependencies:
+    err-code "^2.0.2"
+    retry "^0.12.0"
+
 proxy-addr@~2.0.5:
   version "2.0.6"
   resolved "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.6.tgz#fdc2336505447d3f2f2c638ed272caf614bbb2bf"
@@ -5048,7 +5247,7 @@ release-zalgo@^1.0.0:
   dependencies:
     es6-error "^4.0.1"
 
-request@^2.72.0, request@^2.88.2:
+request@^2.72.0:
   version "2.88.2"
   resolved "https://registry.npmjs.org/request/-/request-2.88.2.tgz#d73c918731cb5a87da047e207234146f664d12b3"
   integrity sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==
@@ -5145,6 +5344,11 @@ restore-cursor@^3.1.0:
     onetime "^5.1.0"
     signal-exit "^3.0.2"
 
+retry@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/retry/-/retry-0.12.0.tgz#1b42a6266a21f07421d1b0b54b7dc167b01c013b"
+  integrity sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=
+
 reusify@^1.0.4:
   version "1.0.4"
   resolved "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
@@ -5207,9 +5411,9 @@ safe-buffer@^5.0.1, safe-buffer@^5.1.2, safe-buffer@~5.2.0:
   resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz#b74daec49b1148f88c64b68d49b1e815c1f2f519"
   integrity sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==
 
-"safer-buffer@>= 2.1.2 < 3", safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
+"safer-buffer@>= 2.1.2 < 3", "safer-buffer@>= 2.1.2 < 3.0.0", safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
   version "2.1.2"
-  resolved "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
+  resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
 scoped-regex@^2.0.0:
@@ -5254,7 +5458,7 @@ semver@^7.1.1:
   resolved "https://registry.npmjs.org/semver/-/semver-7.1.3.tgz#e4345ce73071c53f336445cfc19efb1c311df2a6"
   integrity sha512-ekM0zfiA9SCBlsKa2X1hxyxiI4L3B6EbVJkkdgQXnSEEaHlGdvyodMruTiulSRWMMB4NeIuYNMC9rTKTz97GxA==
 
-semver@^7.3.4:
+semver@^7.3.4, semver@^7.3.5:
   version "7.3.5"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
   integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
@@ -5407,6 +5611,28 @@ slice-ansi@^4.0.0:
     astral-regex "^2.0.0"
     is-fullwidth-code-point "^3.0.0"
 
+smart-buffer@^4.1.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/smart-buffer/-/smart-buffer-4.2.0.tgz#6e1d71fa4f18c05f7d0ff216dd16a481d0e8d9ae"
+  integrity sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==
+
+socks-proxy-agent@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/socks-proxy-agent/-/socks-proxy-agent-5.0.1.tgz#032fb583048a29ebffec2e6a73fca0761f48177e"
+  integrity sha512-vZdmnjb9a2Tz6WEQVIurybSwElwPxMZaIc7PzqbJTrezcKNznv6giT7J7tZDZ1BojVaa1jvO/UiUdhDVB0ACoQ==
+  dependencies:
+    agent-base "^6.0.2"
+    debug "4"
+    socks "^2.3.3"
+
+socks@^2.3.3:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/socks/-/socks-2.6.1.tgz#989e6534a07cf337deb1b1c94aaa44296520d30e"
+  integrity sha512-kLQ9N5ucj8uIcxrDwjm0Jsqk06xdpBjGNQtpXy4Q8/QY2k+fY7nZH8CARy+hkbG+SGAovmzzuauCpBlb8FrnBA==
+  dependencies:
+    ip "^1.1.5"
+    smart-buffer "^4.1.0"
+
 sort-object-keys@^1.1.3:
   version "1.1.3"
   resolved "https://registry.npmjs.org/sort-object-keys/-/sort-object-keys-1.1.3.tgz#bff833fe85cab147b34742e45863453c1e190b45"
@@ -5513,6 +5739,13 @@ sshpk@^1.7.0:
     jsbn "~0.1.0"
     safer-buffer "^2.0.2"
     tweetnacl "~0.14.0"
+
+ssri@^8.0.0, ssri@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/ssri/-/ssri-8.0.1.tgz#638e4e439e2ffbd2cd289776d5ca457c4f51a2af"
+  integrity sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==
+  dependencies:
+    minipass "^3.1.1"
 
 "statuses@>= 1.5.0 < 2", statuses@~1.5.0:
   version "1.5.0"
@@ -5741,7 +5974,7 @@ table@^5.2.3:
     slice-ansi "^2.1.0"
     string-width "^3.0.0"
 
-tar@^6.0.2, tar@^6.1.0:
+tar@^6.0.2, tar@^6.1.0, tar@^6.1.2:
   version "6.1.11"
   resolved "https://registry.yarnpkg.com/tar/-/tar-6.1.11.tgz#6760a38f003afa1b2ffd0ffe9e9abbd0eab3d621"
   integrity sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==
@@ -6095,6 +6328,20 @@ uglify-js@^3.1.4:
   version "3.13.5"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.13.5.tgz#5d71d6dbba64cf441f32929b1efce7365bb4f113"
   integrity sha512-xtB8yEqIkn7zmOyS2zUNBsYCBRhDkvlNxMMY2smuJ/qA8NCHeQvKCF3i9Z4k8FJH4+PJvZRtMrPynfZ75+CSZw==
+
+unique-filename@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/unique-filename/-/unique-filename-1.1.1.tgz#1d69769369ada0583103a1e6ae87681b56573230"
+  integrity sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==
+  dependencies:
+    unique-slug "^2.0.0"
+
+unique-slug@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/unique-slug/-/unique-slug-2.0.2.tgz#baabce91083fc64e945b0f3ad613e264f7cd4e6c"
+  integrity sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==
+  dependencies:
+    imurmurhash "^0.1.4"
 
 unique-string@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
The goal of this PR is to get node-libcurl building properly for Apple silicon. Universal builds seem like they would be ideal, so that is my current goal. Unfortunately, this adds a decent amount of complexity to the build scripts and will necessarily increase build times :( In addition, some workaround may be needed for node-pre-gyp to be able to fetch the universal binaries.

We're working on this in the process of trying to resolve https://github.com/Kong/insomnia/issues/2964.