### PR TITLE
Enable overriding of default curl-config path

### DIFF
--- a/scripts/curl-config.js
+++ b/scripts/curl-config.js
@@ -20,7 +20,9 @@ if (!argv[2]) {
 
 const arg = argv[2].trim()
 
-exec(`curl-config ${arg}`, function (error, stdout, stderr) {
+const curlConfig = process.env.CURL_CONFIG ? process.env.CURL_CONFIG : 'curl-config';
+
+exec(`${curlConfig} ${arg}`, function (error, stdout, stderr) {
   if (error != null) {
     console.error(
       'Could not run curl-config, please make sure libcurl dev package is installed.',


### PR DESCRIPTION
This patch will enable building node-libcurl for embedded targets, for example via buildroot.