### PR TITLE
fix(actions): also run against macos-latest

### DIFF
--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -26,6 +26,7 @@ jobs:
       matrix:
         os:
           - macos-10.15
+          - macos-latest
           - ubuntu-16.04 # TODO(jonathan): bump this to a more recent version when we do a major version bump
         libcurl-release:
           - 7.73.0

--- a/.github/workflows/build-lint-test.yaml
+++ b/.github/workflows/build-lint-test.yaml
@@ -20,6 +20,7 @@ jobs:
       matrix:
         os:
           - macos-10.15
+          - macos-latest
           # removed as we enabled CircleCI to run on PRs
           # - ubuntu-16.04 # TODO(jonathan): bump this to a more recent version when we do a major version bump
         libcurl-release:


### PR DESCRIPTION
This is in reference to: https://github.com/JCMais/node-libcurl/issues/296