### PR TITLE
fix(curly): use default content-type when there are no headers

### DIFF
--- a/lib/curly.ts
+++ b/lib/curly.ts
@@ -380,9 +380,12 @@ const create = (defaultOptions: CurlyOptions = {}): CurlyFunction => {
             return
           }
 
-          const contentTypeEntry = Object.entries(
-            headers[headers.length - 1],
-          ).find(([k]) => k.toLowerCase() === 'content-type')
+          const contentTypeEntry =
+            headers.length > 0
+              ? Object.entries(headers[headers.length - 1]).find(
+                  ([k]) => k.toLowerCase() === 'content-type',
+                )
+              : null
 
           let contentType = (
             contentTypeEntry ? contentTypeEntry[1] : ''


### PR DESCRIPTION
When using a `sftp://` url, this `headers` variable is an empty array, which breaks the `Object.entries` call.

This PR adds a bounds check so the default content-type will be chosen if the headers variable is empty.


I failed to get this to work with my vite-based project, something about 'exports not defined'. It does work if I manually patch the `dist/` javascript. So, I'll leave the verification to you.

Thanks,
Liam