### PR TITLE
fix: macOS x64 prebuilt binary contains arm64 architecture

### DIFF
--- a/scripts/ci/build.sh
+++ b/scripts/ci/build.sh
@@ -494,10 +494,10 @@ if [[ "$MACOS_UNIVERSAL_BUILD" == "true" ]]; then
   # play well with electron-builder which will try to lipo native add-ons
   # for different architectures.
   # --
-  lipo build/Release/node_libcurl.node -thin x86_64 -output lib/binding/node_libcurl.node
   lipo build/Release/node_libcurl.node -thin arm64 -output lib/binding/node_libcurl.node
-
   npm_config_target_arch=arm64 pnpm pregyp package testpackage --verbose
+
+  lipo build/Release/node_libcurl.node -thin x86_64 -output lib/binding/node_libcurl.node
   npm_config_target_arch=x64 pnpm pregyp package testpackage --verbose
 else
   pnpm pregyp package testpackage --verbose

--- a/scripts/ci/build.sh
+++ b/scripts/ci/build.sh
@@ -494,11 +494,24 @@ if [[ "$MACOS_UNIVERSAL_BUILD" == "true" ]]; then
   # play well with electron-builder which will try to lipo native add-ons
   # for different architectures.
   # --
-  lipo build/Release/node_libcurl.node -thin arm64 -output lib/binding/node_libcurl.node
-  npm_config_target_arch=arm64 pnpm pregyp package testpackage --verbose
+  native_arch=$(uname -m)
+  if [ "$native_arch" == "x86_64" ]; then
+    cross_arch="arm64"
+    native_npm_arch="x64"
+    cross_npm_arch="arm64"
+  else
+    cross_arch="x86_64"
+    native_npm_arch="arm64"
+    cross_npm_arch="x64"
+  fi
 
-  lipo build/Release/node_libcurl.node -thin x86_64 -output lib/binding/node_libcurl.node
-  npm_config_target_arch=x64 pnpm pregyp package testpackage --verbose
+  # Package the cross-compiled architecture first (no testpackage - can't load it)
+  lipo build/Release/node_libcurl.node -thin $cross_arch -output lib/binding/node_libcurl.node
+  npm_config_target_arch=$cross_npm_arch pnpm pregyp package --verbose
+
+  # Package the native architecture (with testpackage to verify it loads)
+  lipo build/Release/node_libcurl.node -thin $native_arch -output lib/binding/node_libcurl.node
+  npm_config_target_arch=$native_npm_arch pnpm pregyp package testpackage --verbose
 else
   pnpm pregyp package testpackage --verbose
 fi


### PR DESCRIPTION
## Summary

- Fixes the universal build packaging in `scripts/ci/build.sh` where both `lipo` extractions wrote to the same output file before either was packaged — the arm64 slice overwrote the x86_64 one, so both tarballs contained arm64 binaries
- The fix interleaves extraction and packaging: extract arm64 → package arm64 → extract x86_64 → package x64
- Bug was introduced in 1e2f55e ("ci: attestations") and affects all macOS releases since (v5.0.0 through v5.0.2)

## Test plan

- [x] Built a universal binary locally, ran the fixed lipo+package steps, and verified via `file` that each tarball contains the correct architecture

Fixes #445